### PR TITLE
Set up CI builds for all logos

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,62 @@
+# based on https://github.com/MiyooCFW/gmenunx/blob/master/.github/workflows/c-cpp.yml
+name: CI Build
+
+on: [push, pull_request]
+
+jobs:   
+  build-modern:
+    name: boot logos for MiyooCFW 1.4+ (musl libc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build BittBoy
+      run: make -f Makefile.bittboy
+    - uses: actions/upload-artifact@v2
+      with:
+        name: BittBoy boot logo
+        path: boot-logo
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - name: build PocketGO
+      run: make -f Makefile.bittboy clean; make -f Makefile.pocketgo
+    - uses: actions/upload-artifact@v2
+      with:
+        name: PocketGO boot logo
+        path: boot-logo
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - name: build PowKiddy
+      run: make -f Makefile.pocketgo clean; make -f Makefile.powkiddy
+    - uses: actions/upload-artifact@v2
+      with:
+        name: PowKiddy boot logo
+        path: boot-logo
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+  build-legacy:
+    name: legacy boot logos for Miyoo <=1.3.3 (uClibc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:steward
+    steps:
+    - uses: actions/checkout@v2
+    - name: build BittBoy
+      run: make -f Makefile.bittboy
+    - uses: actions/upload-artifact@v2
+      with:
+        name: legacyBittBoy boot logo
+        path: boot-logo
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - name: build PocketGO
+      run: make -f Makefile.bittboy clean; make -f Makefile.pocketgo
+    - uses: actions/upload-artifact@v2
+      with:
+        name: legacy PocketGO boot logo
+        path: boot-logo
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+    - name: build PowKiddy
+      run: make -f Makefile.pocketgo clean; make -f Makefile.powkiddy
+    - uses: actions/upload-artifact@v2
+      with:
+        name: legacy PowKiddy boot logo
+        path: boot-logo
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`

--- a/Makefile.bittboy
+++ b/Makefile.bittboy
@@ -1,12 +1,15 @@
-CHAINPREFIX=/opt/buildroot-bittboy/output/host
-CROSS_COMPILE=$(CHAINPREFIX)/bin/arm-miyoo-linux-musleabi-
+#CHAINPREFIX ?= /opt/buildroot-bittboy/output/host
+#CROSS_COMPILE ?= $(CHAINPREFIX)/bin/arm-miyoo-linux-musleabi-
+#SYSROOT ?= $(CHAINPREFIX)/arm-miyoo-linux-musleabi/sysroot
+CHAINPREFIX ?= /opt/miyoo
+CROSS_COMPILE ?= $(CHAINPREFIX)/bin/arm-buildroot-linux-musleabi-
+SYSROOT ?= $(CHAINPREFIX)/arm-buildroot-linux-musleabi/sysroot
 
 BUILDTIME=$(shell date +'\"%Y-%m-%d %H:%M\"')
 
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++
 STRIP = $(CROSS_COMPILE)strip
-SYSROOT     := $(CHAINPREFIX)/arm-miyoo-linux-musleabi/sysroot
 SDL_CFLAGS  := $(shell $(SYSROOT)/usr/bin/sdl-config --cflags)
 
 OUTPUTNAME = boot-logo

--- a/Makefile.pocketgo
+++ b/Makefile.pocketgo
@@ -1,12 +1,15 @@
-CHAINPREFIX=/opt/buildroot-bittboy/output/host
-CROSS_COMPILE=$(CHAINPREFIX)/bin/arm-miyoo-linux-musleabi-
+#CHAINPREFIX ?= /opt/buildroot-bittboy/output/host
+#CROSS_COMPILE ?= $(CHAINPREFIX)/bin/arm-miyoo-linux-musleabi-
+#SYSROOT ?= $(CHAINPREFIX)/arm-miyoo-linux-musleabi/sysroot
+CHAINPREFIX ?= /opt/miyoo
+CROSS_COMPILE ?= $(CHAINPREFIX)/bin/arm-buildroot-linux-musleabi-
+SYSROOT ?= $(CHAINPREFIX)/arm-buildroot-linux-musleabi/sysroot
 
 BUILDTIME=$(shell date +'\"%Y-%m-%d %H:%M\"')
 
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++
 STRIP = $(CROSS_COMPILE)strip
-SYSROOT     := $(CHAINPREFIX)/arm-miyoo-linux-musleabi/sysroot
 SDL_CFLAGS  := $(shell $(SYSROOT)/usr/bin/sdl-config --cflags)
 
 OUTPUTNAME = boot-logo

--- a/Makefile.powkiddy
+++ b/Makefile.powkiddy
@@ -1,12 +1,15 @@
-CHAINPREFIX=/opt/buildroot-bittboy/output/host
-CROSS_COMPILE=$(CHAINPREFIX)/bin/arm-miyoo-linux-musleabi-
+#CHAINPREFIX ?= /opt/buildroot-bittboy/output/host
+#CROSS_COMPILE ?= $(CHAINPREFIX)/bin/arm-miyoo-linux-musleabi-
+#SYSROOT ?= $(CHAINPREFIX)/arm-miyoo-linux-musleabi/sysroot
+CHAINPREFIX ?= /opt/miyoo
+CROSS_COMPILE ?= $(CHAINPREFIX)/bin/arm-buildroot-linux-musleabi-
+SYSROOT ?= $(CHAINPREFIX)/arm-buildroot-linux-musleabi/sysroot
 
 BUILDTIME=$(shell date +'\"%Y-%m-%d %H:%M\"')
 
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++
 STRIP = $(CROSS_COMPILE)strip
-SYSROOT     := $(CHAINPREFIX)/arm-miyoo-linux-musleabi/sysroot
 SDL_CFLAGS  := $(shell $(SYSROOT)/usr/bin/sdl-config --cflags)
 
 OUTPUTNAME = boot-logo


### PR DESCRIPTION
Builds all logos on both toolchains.

I had to make a few tweaks to the makefiles to use the correct toolchain paths in the docker images, but I made the vars override-able with env props.