### PR TITLE
disable legacy/steward build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:   
   build-modern:
-    name: boot logos for MiyooCFW 1.4+ (musl libc)
+    name: boot logos for MiyooCFW (musl libc)
     runs-on: ubuntu-20.04
     container:
       image: nfriedly/miyoo-toolchain:latest
@@ -30,33 +30,5 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: PowKiddy boot logo
-        path: boot-logo
-        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-  build-legacy:
-    name: legacy boot logos for Miyoo <=1.3.3 (uClibc)
-    runs-on: ubuntu-20.04
-    container:
-      image: nfriedly/miyoo-toolchain:steward
-    steps:
-    - uses: actions/checkout@v2
-    - name: build BittBoy
-      run: make -f Makefile.bittboy
-    - uses: actions/upload-artifact@v2
-      with:
-        name: legacyBittBoy boot logo
-        path: boot-logo
-        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-    - name: build PocketGO
-      run: make -f Makefile.bittboy clean; make -f Makefile.pocketgo
-    - uses: actions/upload-artifact@v2
-      with:
-        name: legacy PocketGO boot logo
-        path: boot-logo
-        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
-    - name: build PowKiddy
-      run: make -f Makefile.pocketgo clean; make -f Makefile.powkiddy
-    - uses: actions/upload-artifact@v2
-      with:
-        name: legacy PowKiddy boot logo
         path: boot-logo
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`


### PR DESCRIPTION
Similar to with gmenunx, they don't seem to actually work. due to missing libraries. But the modern builds do work, even on 1.3.3, so we'll just make those the only ones.

Also, the number of artifacts was getting a little out-of-hand.