### PR TITLE
fix infinite loop on PlayChannel, add quit case for SDL_Delay + cleanup the code

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
 		}
 	}
 	
-	for (i=1 ; i <= sqrt(ENDDELAY); i++){
+	for (i=1 ; i < (sqrt(2+8*ENDDELAY)-1)/2; i++){
 		SDL_Delay(i);
 		while (SDL_PollEvent(&event)) {
 			switch (event.type) {

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,8 @@
 #include <SDL/SDL_image.h>
 #include <SDL/SDL_mixer.h>
 
+#include <cmath>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "assets.h"
@@ -94,15 +96,6 @@ int main(int argc, char* argv[]) {
 		SDL_BlitSurface(logoimg, NULL, screen, &dstrect);
 		if (i == dest_y) {
 			Mix_PlayChannel(-1, logosound, 0);
-			while(1) {
-				while (SDL_PollEvent(&event)) {
-					switch (event.type) {
-						case SDL_KEYDOWN:
-							exit(0);
-							break;
-					}
-				}
-			}
 		}
 		while (curr_time < old_time + 16) {
 			curr_time = SDL_GetTicks();
@@ -110,8 +103,29 @@ int main(int argc, char* argv[]) {
 		old_time = curr_time;
 		SDL_Flip(screen);
 	}
-
-	SDL_Delay(ENDDELAY);
+	
+	int i;
+	
+	while(Mix_Playing(-1)) {
+		while (SDL_PollEvent(&event)) {
+			switch (event.type) {
+				case SDL_KEYDOWN:
+					exit(0);
+					break;
+			}
+		}
+	}
+	
+	for (i=1 ; i <= sqrt(ENDDELAY); i++){
+		SDL_Delay(i);
+		while (SDL_PollEvent(&event)) {
+			switch (event.type) {
+				case SDL_KEYDOWN:
+					exit(0);
+					break;
+			}
+		}
+	}
 
 	SDL_FreeRW(RWops);
 	SDL_FreeRW(RWops2);

--- a/main.cpp
+++ b/main.cpp
@@ -104,8 +104,6 @@ int main(int argc, char* argv[]) {
 		SDL_Flip(screen);
 	}
 	
-	int i;
-	
 	while(Mix_Playing(-1)) {
 		while (SDL_PollEvent(&event)) {
 			switch (event.type) {
@@ -116,8 +114,8 @@ int main(int argc, char* argv[]) {
 		}
 	}
 	
-	for (i=1 ; i < (sqrt(2+8*ENDDELAY)-1)/2; i++){
-		SDL_Delay(i);
+	for (int j = 0 ; j < (sqrt(2+8*ENDDELAY)-1)/2; j++){
+		SDL_Delay(j);
 		while (SDL_PollEvent(&event)) {
 			switch (event.type) {
 				case SDL_KEYDOWN:

--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,17 @@
 
 //---------------------------------------------------//
 
+void exit_event() {
+	SDL_Event event;
+	while (SDL_PollEvent(&event)) {
+		switch (event.type) {
+			case SDL_KEYDOWN:
+				exit(0);
+				break;
+		}
+	}
+}
+
 
 int main(int argc, char* argv[]) {
 	if (SDL_Init(SDL_INIT_VIDEO|SDL_INIT_AUDIO) != 0) {
@@ -77,13 +88,7 @@ int main(int argc, char* argv[]) {
 	SDL_Rect dstrect;
 	SDL_Event event;
 	for (int i = 0 - logoimg->h - ANIMDELAY; i <= dest_y; i = i + ANIMSPEED) {
-		while (SDL_PollEvent(&event)) {
-			switch (event.type) {
-				case SDL_KEYDOWN:
-					exit(0);
-					break;
-			}
-		}
+		exit_event();
 		rect.x = 0;
 		rect.y = 0;
 		rect.w = screen->w;
@@ -105,24 +110,12 @@ int main(int argc, char* argv[]) {
 	}
 	
 	while(Mix_Playing(-1)) {
-		while (SDL_PollEvent(&event)) {
-			switch (event.type) {
-				case SDL_KEYDOWN:
-					exit(0);
-					break;
-			}
-		}
+		exit_event();
 	}
 	
 	for (int j = 0 ; j < (sqrt(2+8*ENDDELAY)-1)/2; j++){
 		SDL_Delay(j);
-		while (SDL_PollEvent(&event)) {
-			switch (event.type) {
-				case SDL_KEYDOWN:
-					exit(0);
-					break;
-			}
-		}
+		exit_event();
 	}
 
 	SDL_FreeRW(RWops);


### PR DESCRIPTION
It was looping infinitely with ``while (1)`` previously, so I added ``for`` with ENDDELAY in quadratic equation. Boot-logo plays now 2÷3 frames longer to definied one, but it doesn't matter much as we can quit at any moment.